### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,22 +30,24 @@ addons:
     sources:
       - mysql-5.7-trusty
     packages:
+      - dpkg
       - mysql-server
       - mysql-client
+install: 
+    - sudo apt-get -y -q -m --no-install-suggests --no-install-recommends --allow-unauthenticated $(travis_apt_get_options) install dpkg mysql-server mysql-client 
 before_install:
     #update packages in quite mode.
-    - sudo apt-get update
+    - sudo apt-get -q update
     #install postfix mail server
-    - sudo apt-get install postfix
+    - sudo apt-get -y install postfix
     #create a test database
     - mysql -e 'create database if not exists testing_db;'
     - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('123456') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
     - sudo mysql_upgrade -u root -p123456
     - sudo service mysql restart
-    
 before_script:
     - composer self-update
-    - composer install --prefer-source --no-interaction --dev
+    - composer install --prefer-source --no-interaction
 script:
     - phpunit --configuration phpunit.xml
 after_success:


### PR DESCRIPTION
## Summary
These are some changes to improve testing environment and enabling error-making non-deterministic jobs in Travis-ci.

## Travis messages
**--dev flag:** 
`You are using the deprecated option "dev". Dev packages are installed by default now.`
I removed the flag

**phpunit/phpunit-mock-objects  package:**
`Package phpunit/phpunit-mock-objects is *abandoned*, you should avoid using it. No replacement was suggested.`

## Other changes
**dpkg:**
To be able to use `--allow-unauthenticated` flag to bypass mongodb Error.

**-y:**
Use the -y parameter with apt-get to assume yes to all queries by the apt tools. Postfix was not installed because -y was not available. So, I added the flag.

**-q:**
Quiet.